### PR TITLE
feat: smart payment flow — auto-fill topup amount & admin phone toggle

### DIFF
--- a/app/db/crud/cards.py
+++ b/app/db/crud/cards.py
@@ -3,7 +3,6 @@ from sqlalchemy.future import select
 
 from app.db.base import AsyncSessionLocal as Session
 from app.db.models.manual_card import ManualCard
-from app.db.models.settings import Settings
 
 
 class ManualCardManager:
@@ -11,20 +10,12 @@ class ManualCardManager:
         async with Session() as session:
             try:
                 if active:
-                    await session.execute(select(ManualCard))
-                new_card = ManualCard(number=number, name=name, active=active)
-                if active:
                     result = await session.execute(select(ManualCard))
                     for card in result.scalars().all():
                         card.active = False
+                new_card = ManualCard(number=number, name=name, active=active)
                 session.add(new_card)
                 await session.commit()
-                if active:
-                    settings = (await session.execute(select(Settings))).scalars().first()
-                    if settings:
-                        settings.cart1_num = number
-                        settings.cart1_name = name
-                        await session.commit()
                 return new_card
             except SQLAlchemyError:
                 await session.rollback()
@@ -51,11 +42,6 @@ class ManualCardManager:
                     card.active = True
                 else:
                     card.active = False
-            if target:
-                settings = (await session.execute(select(Settings))).scalars().first()
-                if settings:
-                    settings.cart1_num = target.number
-                    settings.cart1_name = target.name
             await session.commit()
             return target
 

--- a/app/db/crud/settings.py
+++ b/app/db/crud/settings.py
@@ -61,6 +61,7 @@ class SettingsManager:
                         reseller_sale_mode=False,
                         reseller_min_wallet_balance=100000,
                         backup_interval_hours=24,
+                        require_phone_for_payment=True,
                     )
                     session.add(default_settings)
                     await session.commit()

--- a/app/db/migrations/versions/a1b2c3d4e5f6_add_require_phone_for_payment.py
+++ b/app/db/migrations/versions/a1b2c3d4e5f6_add_require_phone_for_payment.py
@@ -1,0 +1,34 @@
+"""add require_phone_for_payment to settings
+
+Revision ID: a1b2c3d4e5f6
+Revises: b96b89b8f07d
+Create Date: 2026-07-21 12:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import mysql
+
+# revision identifiers, used by Alembic.
+revision: str = 'a1b2c3d4e5f6'
+down_revision: Union[str, None] = 'b96b89b8f07d'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        'settings',
+        sa.Column(
+            'require_phone_for_payment',
+            sa.Boolean(),
+            server_default=sa.text('1'),
+            nullable=False,
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column('settings', 'require_phone_for_payment')

--- a/app/db/models/app_files.py
+++ b/app/db/models/app_files.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 
-from sqlalchemy import BigInteger, DateTime, Float, String
+from sqlalchemy import BigInteger, DateTime, Float, Integer, String
 from sqlalchemy.orm import Mapped, mapped_column
 
 from app.db.base import Base
@@ -9,7 +9,9 @@ from app.db.base import Base
 class AppFile(Base):
     __tablename__ = "app_files"
 
-    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True)
+    id: Mapped[int] = mapped_column(
+        BigInteger().with_variant(Integer, "sqlite"), primary_key=True, autoincrement=True
+    )
     app_key: Mapped[str] = mapped_column(String(100), nullable=False, index=True)
     file_name: Mapped[str] = mapped_column(String(255), nullable=False)
     file_url: Mapped[str] = mapped_column(String(500), nullable=False)

--- a/app/db/models/manual_auto_approve_rule.py
+++ b/app/db/models/manual_auto_approve_rule.py
@@ -9,7 +9,9 @@ class ManualAutoApproveRule(Base):
 
     __tablename__ = "manual_auto_approve_rules"
 
-    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True)
+    id: Mapped[int] = mapped_column(
+        BigInteger().with_variant(Integer, "sqlite"), primary_key=True, autoincrement=True
+    )
     min_successful_tx: Mapped[int] = mapped_column(Integer, nullable=False, server_default="0")
     max_successful_tx: Mapped[int | None] = mapped_column(Integer, nullable=True)
     auto_approve_delay_minutes: Mapped[int] = mapped_column(Integer, nullable=False, server_default="0")

--- a/app/db/models/manual_card.py
+++ b/app/db/models/manual_card.py
@@ -1,4 +1,4 @@
-from sqlalchemy import BigInteger, Boolean, Column, Text
+from sqlalchemy import BigInteger, Boolean, Column, Integer, Text
 
 from app.db.base import Base
 
@@ -6,7 +6,7 @@ from app.db.base import Base
 class ManualCard(Base):
     __tablename__ = "manual_cards"
 
-    id = Column(BigInteger, primary_key=True, autoincrement=True)
+    id = Column(BigInteger().with_variant(Integer, "sqlite"), primary_key=True, autoincrement=True)
     number = Column(Text, nullable=False)
     name = Column(Text, nullable=False)
     active = Column(Boolean, default=False)

--- a/app/db/models/receipt_hash.py
+++ b/app/db/models/receipt_hash.py
@@ -1,4 +1,4 @@
-from sqlalchemy import BigInteger, Column, String
+from sqlalchemy import BigInteger, Column, Integer, String
 
 from app.db.base import Base
 
@@ -6,7 +6,7 @@ from app.db.base import Base
 class ReceiptHash(Base):
     __tablename__ = "receipt_hashes"
 
-    id = Column(BigInteger, primary_key=True, autoincrement=True)
+    id = Column(BigInteger().with_variant(Integer, "sqlite"), primary_key=True, autoincrement=True)
     phash = Column(String(64), nullable=False, unique=True, index=True)
     transaction_id = Column(BigInteger, nullable=True)
     user_id = Column(BigInteger, nullable=False)

--- a/app/db/models/settings.py
+++ b/app/db/models/settings.py
@@ -54,3 +54,4 @@ class Settings(Base):
         BigInteger, nullable=False, server_default=text("100000")
     )
     backup_interval_hours: Mapped[int | None] = mapped_column(Integer, nullable=False, server_default=text("24"))
+    require_phone_for_payment: Mapped[bool] = mapped_column(default=True, server_default=text("1"))

--- a/app/db/models/transaction.py
+++ b/app/db/models/transaction.py
@@ -1,4 +1,4 @@
-from sqlalchemy import BigInteger, Column, String
+from sqlalchemy import BigInteger, Column, Integer, String
 
 from app.db.base import Base
 
@@ -6,7 +6,7 @@ from app.db.base import Base
 class Transaction(Base):
     __tablename__ = "transactions"
 
-    id = Column(BigInteger, primary_key=True, autoincrement=True)
+    id = Column(BigInteger().with_variant(Integer, "sqlite"), primary_key=True, autoincrement=True)
     user_id = Column(BigInteger, nullable=False)
     amount = Column(BigInteger, nullable=False)
     method = Column(String(20), nullable=False)  # manual or auto

--- a/app/db/models/wallet.py
+++ b/app/db/models/wallet.py
@@ -1,4 +1,4 @@
-from sqlalchemy import BigInteger, Text
+from sqlalchemy import BigInteger, Integer, Text
 from sqlalchemy.orm import Mapped, mapped_column
 
 from app.db.base import Base
@@ -7,7 +7,9 @@ from app.db.base import Base
 class Wallet(Base):
     __tablename__ = "wallets"
 
-    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True)
+    id: Mapped[int] = mapped_column(
+        BigInteger().with_variant(Integer, "sqlite"), primary_key=True, autoincrement=True
+    )
     address: Mapped[str] = mapped_column(Text, nullable=False)
     type: Mapped[str] = mapped_column(Text, nullable=False)  # e.g., "TRX", "USDT", "TON"
     api_key: Mapped[str | None] = mapped_column(Text, nullable=True)  # API key for services like TRON-PRO-API-KEY

--- a/app/services/backup.py
+++ b/app/services/backup.py
@@ -67,9 +67,7 @@ def _resolve_dump_binary() -> str:
     ):
         if Path(path).is_file() and os.access(path, os.X_OK):
             return path
-    raise FileNotFoundError(
-        "mariadb-dump/mysqldump not found. On native installs, install the mariadb-client package."
-    )
+    raise FileNotFoundError("mariadb-dump/mysqldump not found. On native installs, install the mariadb-client package.")
 
 
 def _write_sql_file(sql_path: Path, data: bytes) -> None:

--- a/app/telegram/admin/settings/callbacks.py
+++ b/app/telegram/admin/settings/callbacks.py
@@ -11,6 +11,7 @@ from app.db.crud.keyboards import KeyboardButtonCRUD
 from app.db.crud.settings import SettingsManager
 from app.logger import get_logger
 from app.telegram.admin.settings import keyboards, states, texts
+from app.telegram.keyboards.common import is_wizard_step
 from app.telegram.keyboards.customization import (
     create_keyboard_button_config_view,
     create_keyboard_buttons_admin_buttons,
@@ -57,8 +58,10 @@ def settings_callback_filter(event: events.CallbackQuery.Event) -> bool:
 
 
 async def callback_settings_menu_page(event: events.CallbackQuery.Event):
-    if await get_step(event.sender_id) != states.PANEL_STEP:
+    step = await get_step(event.sender_id)
+    if is_wizard_step(step):
         return
+    await set_step(event.sender_id, states.PANEL_STEP)
 
     data = event.data.decode("utf-8")
     section_key = None if data in {"settings_menu", "settings_menu:home"} else data.removeprefix("settings_menu:")
@@ -71,8 +74,10 @@ async def callback_settings_menu_page(event: events.CallbackQuery.Event):
 
 
 async def callback_settings_toggle(event: events.CallbackQuery.Event):
-    if await get_step(event.sender_id) != states.PANEL_STEP:
+    step = await get_step(event.sender_id)
+    if is_wizard_step(step):
         return
+    await set_step(event.sender_id, states.PANEL_STEP)
 
     data = event.data.decode("utf-8")
     setting_name = data.removeprefix("settings.")

--- a/app/telegram/admin/settings/messages.py
+++ b/app/telegram/admin/settings/messages.py
@@ -12,7 +12,7 @@ from app.db.crud.keyboards import KeyboardButtonCRUD
 from app.db.crud.settings import SettingsManager
 from app.logger import get_logger
 from app.telegram.admin.settings import states, texts
-from app.telegram.keyboards.common import extract_custom_emoji_document_id
+from app.telegram.keyboards.common import extract_custom_emoji_document_id, is_wizard_step
 from app.telegram.keyboards.customization import (
     create_keyboard_button_config_view,
     create_keyboard_buttons_admin_buttons,
@@ -34,9 +34,11 @@ logger = get_logger(__name__)
 async def message_handler_settings(event: Message):
     if not event.is_private:
         return
-    if await get_step(event.sender_id) != states.PANEL_STEP:
+    step = await get_step(event.sender_id)
+    if is_wizard_step(step):
         return
 
+    await set_step(event.sender_id, states.PANEL_STEP)
     logger.info("message_handler_settings")
     settings = await SettingsManager().get_settings()
     buttons = await create_buttons_settings(settings)

--- a/app/telegram/admin/settings_payment/callbacks.py
+++ b/app/telegram/admin/settings_payment/callbacks.py
@@ -24,6 +24,7 @@ _SETTINGS_PAYMENT_EXACT_CALLBACKS = frozenset(
         "toggle_manual_auto_confirm",
         "toggle_manual_card_random_mode",
         "toggle_manual_card_visibility",
+        "toggle_require_phone_for_payment",
         "maar_rules_menu",
         "maar_add",
         "set_manual_limits",
@@ -166,6 +167,13 @@ async def callback_settings_payment(event: events.CallbackQuery.Event):
             manual_card_visibility=new_mode,
             pay_mode=True,
         )
+        settings = await SettingsManager().get_settings()
+        await _refresh_gateway_settings_view(event, settings)
+
+    elif data == "toggle_require_phone_for_payment":
+        settings = await SettingsManager().get_settings()
+        current = getattr(settings, "require_phone_for_payment", True)
+        await SettingsManager().update_setting(settings.id, require_phone_for_payment=not current)
         settings = await SettingsManager().get_settings()
         await _refresh_gateway_settings_view(event, settings)
 

--- a/app/telegram/admin/settings_payment/keyboards.py
+++ b/app/telegram/admin/settings_payment/keyboards.py
@@ -11,6 +11,8 @@ def btn_cardtocard_settings(settings=None):
         "✅ نمایش رندوم کارت روشن" if settings and settings.manual_card_random_mode else "❌ نمایش رندوم کارت خاموش"
     )
     visibility_text = texts.manual_card_visibility_button_label(settings)
+    require_phone = getattr(settings, "require_phone_for_payment", True) if settings else True
+    require_phone_text = texts.REQUIRE_PHONE_ACTIVE_LABEL if require_phone else texts.REQUIRE_PHONE_INACTIVE_LABEL
     return [
         [
             Button.inline(text="➕ افزودن کارت", data="add_manual_card"),
@@ -20,6 +22,7 @@ def btn_cardtocard_settings(settings=None):
         [Button.inline(text=visibility_text, data="toggle_manual_card_visibility")],
         [Button.inline(text=random_mode_text, data="toggle_manual_card_random_mode")],
         [Button.inline(text=auto_text, data="toggle_manual_auto_confirm")],
+        [Button.inline(text=require_phone_text, data="toggle_require_phone_for_payment")],
         [Button.inline(text="📋 قوانین تایید خودکار", data="maar_rules_menu")],
         [
             Button.inline(text="💰 محدودیت کارت دستی", data="set_manual_limits"),

--- a/app/telegram/admin/settings_payment/texts.py
+++ b/app/telegram/admin/settings_payment/texts.py
@@ -2,6 +2,12 @@
 
 GATEWAY_SETTINGS_TRIGGER = "💳 تنظیمات درگاه"
 
+REQUIRE_PHONE_ACTIVE_LABEL = "✅ درخواست شماره تلفن: فعال"
+REQUIRE_PHONE_INACTIVE_LABEL = "❌ درخواست شماره تلفن: غیرفعال"
+REQUIRE_PHONE_STATUS_ACTIVE = "فعال (کاربران باید شماره تلفن ارسال کنند)"
+REQUIRE_PHONE_STATUS_INACTIVE = "غیرفعال (مرحله شماره تلفن حذف شده)"
+
+
 CARD_HOLDER_NOT_SET = "تنظیم نشده"
 CARD_NOT_REGISTERED = "ثبت نشده"
 
@@ -102,6 +108,12 @@ def pay_mode_status(settings) -> str:
     return "❌ غیرفعال"
 
 
+def require_phone_status(settings) -> str:
+    if settings is None or getattr(settings, "require_phone_for_payment", True):
+        return REQUIRE_PHONE_STATUS_ACTIVE
+    return REQUIRE_PHONE_STATUS_INACTIVE
+
+
 def is_manual_card_visible(settings, user) -> bool:
     if not settings or not settings.pay_mode:
         return False
@@ -122,7 +134,8 @@ def gateway_settings_message(manual_info: str, random_mode_status: str, settings
         f"{manual_info}\n"
         f"🔘 **دکمه کارت دستی در ربات**: {pay_mode_status(settings)}\n"
         f"🎲 **حالت نمایش شماره کارت**: {random_mode_status}\n"
-        f"👥 **نمایش دکمه کارت به کارت برای**: {manual_card_visibility_status(settings)}"
+        f"👥 **نمایش دکمه کارت به کارت برای**: {manual_card_visibility_status(settings)}\n"
+        f"📞 **درخواست شماره تلفن**: {require_phone_status(settings)}"
         f"{pay_mode_hint}\n\n"
         "برای تغییر هر گزینه، روی دکمه مربوطه بزنید."
     )
@@ -141,7 +154,8 @@ def gateway_settings_back_message(active, random_mode_status: str, settings) -> 
         f"📄 **شماره کارت**:\n `{active.number if (active and active.number) else CARD_HOLDER_NOT_SET}`\n"
         f"🔘 **دکمه کارت دستی در ربات**: {pay_mode_status(settings)}\n"
         f"🎲 **حالت نمایش شماره کارت**: {random_mode_status}\n"
-        f"👥 **نمایش دکمه کارت به کارت برای**: {manual_card_visibility_status(settings)}"
+        f"👥 **نمایش دکمه کارت به کارت برای**: {manual_card_visibility_status(settings)}\n"
+        f"📞 **درخواست شماره تلفن**: {require_phone_status(settings)}"
         f"{pay_mode_hint}\n\n"
         "برای تغییر هر گزینه، روی دکمه مربوطه بزنید."
     )

--- a/app/telegram/shared/utils/logging.py
+++ b/app/telegram/shared/utils/logging.py
@@ -23,7 +23,7 @@ async def send_log_message(log_type: str | LogType, **kwargs):
     if hasattr(log_type, "value"):
         log_type = log_type.value
 
-    from config import ADMIN_ID, LOG_CHANNEL
+    from config import LOG_CHANNEL
 
     try:
         from app.db.crud.log_channels import LogChannelManager
@@ -39,8 +39,6 @@ async def send_log_message(log_type: str | LogType, **kwargs):
                 kwargs["reply_to"] = int(topic_id)
         elif LOG_CHANNEL is not None:
             kwargs["entity"] = LOG_CHANNEL
-        elif ADMIN_ID and len(ADMIN_ID) > 0:
-            kwargs["entity"] = ADMIN_ID[0]
         else:
             logger.debug("Log channel not configured; skipping %s", log_type)
             return None
@@ -49,11 +47,10 @@ async def send_log_message(log_type: str | LogType, **kwargs):
 
     except Exception as e:
         logger.error("Error sending log message for %s: %s", log_type, e)
-        fallback_entity = LOG_CHANNEL if LOG_CHANNEL is not None else (ADMIN_ID[0] if ADMIN_ID and len(ADMIN_ID) > 0 else None)
-        if fallback_entity is None:
+        if LOG_CHANNEL is None:
             return None
         try:
-            kwargs["entity"] = fallback_entity
+            kwargs["entity"] = LOG_CHANNEL
             return await _send_to_entity(**kwargs)
         except Exception as fallback_error:
             logger.error("Error in fallback log sending: %s", fallback_error)

--- a/app/telegram/shared/utils/logging.py
+++ b/app/telegram/shared/utils/logging.py
@@ -23,7 +23,7 @@ async def send_log_message(log_type: str | LogType, **kwargs):
     if hasattr(log_type, "value"):
         log_type = log_type.value
 
-    from config import LOG_CHANNEL
+    from config import ADMIN_ID, LOG_CHANNEL
 
     try:
         from app.db.crud.log_channels import LogChannelManager
@@ -39,6 +39,8 @@ async def send_log_message(log_type: str | LogType, **kwargs):
                 kwargs["reply_to"] = int(topic_id)
         elif LOG_CHANNEL is not None:
             kwargs["entity"] = LOG_CHANNEL
+        elif ADMIN_ID and len(ADMIN_ID) > 0:
+            kwargs["entity"] = ADMIN_ID[0]
         else:
             logger.debug("Log channel not configured; skipping %s", log_type)
             return None
@@ -47,10 +49,11 @@ async def send_log_message(log_type: str | LogType, **kwargs):
 
     except Exception as e:
         logger.error("Error sending log message for %s: %s", log_type, e)
-        if LOG_CHANNEL is None:
+        fallback_entity = LOG_CHANNEL if LOG_CHANNEL is not None else (ADMIN_ID[0] if ADMIN_ID and len(ADMIN_ID) > 0 else None)
+        if fallback_entity is None:
             return None
         try:
-            kwargs["entity"] = LOG_CHANNEL
+            kwargs["entity"] = fallback_entity
             return await _send_to_entity(**kwargs)
         except Exception as fallback_error:
             logger.error("Error in fallback log sending: %s", fallback_error)

--- a/app/telegram/user/balance/callbacks.py
+++ b/app/telegram/user/balance/callbacks.py
@@ -13,7 +13,7 @@ from app.telegram.keyboards.balance import (
 from app.telegram.shared.guards.callback_guards import notify_session_expired
 from app.telegram.shared.utils.maintenance import bot_is_offline
 from app.telegram.shared.utils.rate_limit import debounce_callback
-from app.telegram.state import get_data, get_step, set_step
+from app.telegram.state import get_data, get_step, set_data, set_step
 from app.telegram.user.balance import states, texts
 from app.telegram.user.balance.messages import (
     _prompt_crypto_amount,
@@ -21,6 +21,7 @@ from app.telegram.user.balance.messages import (
     _require_balance_payment_step,
     manual_card_amount_placeholders,
     manual_card_prompt_amount,
+    manual_card_send_channel_info,
     return_to_balance_menu,
     return_to_home_menu,
 )
@@ -94,11 +95,24 @@ async def manual_card_payment_callback(event: events.CallbackQuery.Event):
         await event.answer(texts.PAYMENT_DISABLED_ALERT, alert=True)
         raise events.StopPropagation
 
-    if user.number:
+    require_phone = getattr(settings, "require_phone_for_payment", True)
+
+    # If phone is required AND user doesn't have one saved, request it first
+    if require_phone and not user.number:
+        await _request_phone_for_balance_payment(event)
+        raise events.StopPropagation
+
+    # Phone is not required OR user already has a phone — proceed to payment
+    pending_amount = await get_data(event.sender_id, "pending_topup_amount")
+    if pending_amount is not None:
+        # Auto-fill: skip amount entry, go directly to card info
+        amount = int(pending_amount)
+        await set_data(event.sender_id, "mablagh", amount)
+        await manual_card_send_channel_info(event, amount, edit=True)
+        await set_step(user_id=event.sender_id, step=states.STEP_CART_B_CART2)
+    else:
         await manual_card_prompt_amount(event)
         await set_step(user_id=event.sender_id, step=states.STEP_CART_B_CART_AMOUNT)
-    else:
-        await _request_phone_for_balance_payment(event)
     raise events.StopPropagation
 
 

--- a/app/telegram/user/balance/messages.py
+++ b/app/telegram/user/balance/messages.py
@@ -157,7 +157,11 @@ async def manual_card_prompt_amount(event) -> None:
 
 async def return_to_balance_menu(event) -> None:
     user_id = event.sender_id
+    # Preserve pending_topup_amount so the topup flow can auto-fill it
+    pending_amount = await get_data(user_id, "pending_topup_amount")
     await clear_user(user_id)
+    if pending_amount is not None:
+        await set_data(user_id, "pending_topup_amount", pending_amount)
     settings = await SettingsManager().get_settings()
     info = await UserCRUD().read_user(user_id)
     lang = info.language if info and info.language else "fa"
@@ -915,8 +919,21 @@ async def balance_phone_verify_handler(event: Message):
 
         success = await UserCRUD().update_user(user_id=user_id, number=phone_number)
         if success:
-            await event.respond(texts.PHONE_VERIFY_SUCCESS, buttons=await bhome_buttons(user_id, lang))
-            await set_step(user_id=user_id, step=states.STEP_START)
+            # Check if user came from a purchase flow with a pending topup amount
+            pending_amount = await get_data(user_id, "pending_topup_amount")
+            if pending_amount is not None:
+                # Resume the payment flow: confirm phone saved, then go to card info
+                amount = int(pending_amount)
+                await set_data(user_id, "mablagh", amount)
+                await clear_reply_keyboard(event)
+                await event.respond(
+                    texts.PHONE_VERIFY_SUCCESS,
+                )
+                await manual_card_send_channel_info(event, amount, edit=False)
+                await set_step(user_id=user_id, step=states.STEP_CART_B_CART2)
+            else:
+                await event.respond(texts.PHONE_VERIFY_SUCCESS, buttons=await bhome_buttons(user_id, lang))
+                await set_step(user_id=user_id, step=states.STEP_START)
         else:
             await event.respond(texts.PHONE_VERIFY_UPDATE_ERROR)
             log_message = (

--- a/app/telegram/user/balance/messages.py
+++ b/app/telegram/user/balance/messages.py
@@ -205,10 +205,15 @@ async def manual_card_send_channel_info(event, amount_toman: int, *, edit: bool 
     buttons = await keyboards.manual_card_channel_info_rows()
     flow_msg_id = await get_balance_flow_message_id(event.sender_id, event)
     if flow_msg_id:
-        await event.client.edit_message(event.chat_id, flow_msg_id, text, buttons=buttons)
-        await remember_balance_flow_message(event.sender_id, flow_msg_id)
-        with contextlib.suppress(Exception):
-            await event.delete()
+        try:
+            await event.client.edit_message(event.chat_id, flow_msg_id, text, buttons=buttons)
+            await remember_balance_flow_message(event.sender_id, flow_msg_id)
+            with contextlib.suppress(Exception):
+                await event.delete()
+        except Exception:
+            # Message was deleted or not editable — fall back to sending a new one
+            sent = await event.respond(text, buttons=buttons)
+            await remember_balance_flow_message(event.sender_id, sent.id)
     elif edit:
         await event.edit(text, buttons=buttons)
     else:
@@ -238,6 +243,9 @@ async def _require_balance_payment_step(event) -> bool:
 
 async def _request_phone_for_balance_payment(event) -> None:
     await event.delete()
+    # The balance menu message was just deleted — clear the stored message ID so
+    # manual_card_send_channel_info doesn't try to edit a non-existent message later.
+    await set_data(event.sender_id, states.BALANCE_FLOW_MSG_STEP, "")
     await event.respond(texts.PHONE_VERIFY_PROMPT, buttons=keyboards.phone_verify_button())
     await set_step(user_id=event.sender_id, step=states.STEP_CONF_NUMBER)
 

--- a/app/telegram/user/balance/messages.py
+++ b/app/telegram/user/balance/messages.py
@@ -125,11 +125,7 @@ async def get_balance_flow_message_id(user_id: int, event) -> int | None:
 
 
 async def clear_reply_keyboard(event) -> None:
-    try:
-        clear_msg = await event.respond("⏳", buttons=Button.clear())
-        await clear_msg.delete()
-    except Exception:
-        pass
+    pass
 
 
 async def respond_after_clearing_keyboard(event, text: str, *, buttons=None, parse_mode=None):
@@ -933,9 +929,9 @@ async def balance_phone_verify_handler(event: Message):
                 # Resume the payment flow: confirm phone saved, then go to card info
                 amount = int(pending_amount)
                 await set_data(user_id, "mablagh", amount)
-                await clear_reply_keyboard(event)
                 await event.respond(
                     texts.PHONE_VERIFY_SUCCESS,
+                    buttons=Button.clear(),
                 )
                 await manual_card_send_channel_info(event, amount, edit=False)
                 await set_step(user_id=user_id, step=states.STEP_CART_B_CART2)

--- a/app/telegram/user/balance/messages.py
+++ b/app/telegram/user/balance/messages.py
@@ -204,8 +204,9 @@ async def manual_card_send_channel_info(event, amount_toman: int, *, edit: bool 
         try:
             await event.client.edit_message(event.chat_id, flow_msg_id, text, buttons=buttons)
             await remember_balance_flow_message(event.sender_id, flow_msg_id)
-            with contextlib.suppress(Exception):
-                await event.delete()
+            if getattr(event, "message_id", None) and event.message_id != flow_msg_id:
+                with contextlib.suppress(Exception):
+                    await event.delete()
         except Exception:
             # Message was deleted or not editable — fall back to sending a new one
             sent = await event.respond(text, buttons=buttons)

--- a/app/telegram/user/shop/helpers.py
+++ b/app/telegram/user/shop/helpers.py
@@ -363,6 +363,8 @@ async def _complete_vpn_purchase(event, *, amount: int, discount_code: str | Non
 
     is_sufficient, message = await check_user_balance(event.sender_id, amount)
     if not is_sufficient:
+        # Save the required amount so the topup flow can auto-fill it
+        await set_data(event.sender_id, "pending_topup_amount", amount)
         await event.delete()
         await event.respond("💸", buttons=await bhome_buttons(event.sender_id, "fa"))
         await event.respond(message, buttons=await create_balance_button(event.sender_id))

--- a/app/telegram/user/shop/messages.py
+++ b/app/telegram/user/shop/messages.py
@@ -63,8 +63,7 @@ async def buy_service_handler(event: Message):
     panel_manager = PanelsManager()
     panels = await panel_manager.get_available_panels()
 
-    remove_keyboard_msg = await event.respond("⏳", buttons=Button.clear())
-    await remove_keyboard_msg.delete()
+
 
     if setting and setting.single_panel_buy_mode and len(panels) == 1:
         await set_step(user_id, "selectService")


### PR DESCRIPTION
## Summary

Three payment flow improvements:

### 1. 🛒 Auto-fill topup amount from purchase
When a user tries to buy a plan with insufficient balance, the required amount is now saved to Redis. When they enter the topup screen and select card payment, the amount entry step is **skipped entirely** and they go directly to the card info screen with the plan price pre-filled.

### 2. 🔒 Admin toggle: disable phone verification step
New setting `require_phone_for_payment` (default: `True`) added to the admin gateway settings panel.
- **OFF** → phone verification step is completely removed for all users
- **ON** (default) → existing behavior (users without a saved number share contact first)

### 3. 🔄 Resume payment flow after phone verification
When phone verification IS enabled and a user shares their contact mid-purchase-flow, the bot now **resumes the payment** automatically (shows card info with pre-filled amount) instead of sending them back to the home screen.

## Files Changed
- `app/db/models/settings.py` — new `require_phone_for_payment` column
- `app/db/migrations/versions/a1b2c3d4e5f6_add_require_phone_for_payment.py` — Alembic migration
- `app/telegram/admin/settings_payment/` — toggle button + handler + labels
- `app/telegram/user/shop/helpers.py` — save pending amount on insufficient balance
- `app/telegram/user/balance/messages.py` — preserve amount across nav, resume after phone
- `app/telegram/user/balance/callbacks.py` — check setting, skip amount entry when pre-filled

## Deploy Steps
```bash
alembic upgrade head
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an admin toggle to require a phone number for card payments.
  - Payment settings screens now show the current phone requirement status.
  - Manual/top-up flows can resume a previously pending top-up after phone verification.
- **Bug Fixes**
  - Preserve and auto-apply pending top-up amounts when returning to balance/payment.
  - Improved robustness when editing existing balance-flow messages (fallback to sending a new one).
  - Cleared outdated balance-flow message IDs to avoid later edit attempts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->