### PR TITLE
feat: add direct-pay renew for VPN config renewals

### DIFF
--- a/app/db/models/settings.py
+++ b/app/db/models/settings.py
@@ -45,6 +45,7 @@ DEFAULT_PURCHASE_SETTINGS: dict[str, Any] = {
     "test_panel_id": 0,
     "test_phone_verify": True,
     "direct_pay_purchase_mode": False,
+    "direct_pay_renew_mode": False,
 }
 
 DEFAULT_SERVICE_TOOLS_SETTINGS: dict[str, Any] = {

--- a/app/services/billing/direct_pay_flow.py
+++ b/app/services/billing/direct_pay_flow.py
@@ -1,4 +1,4 @@
-"""Shared helpers for direct-pay top-up flow (VPN / reseller)."""
+"""Shared helpers for direct-pay top-up flow (VPN / reseller / renew)."""
 
 from __future__ import annotations
 
@@ -43,6 +43,16 @@ INSUFFICIENT_BALANCE_DIRECT_PAY_DEFAULT = (
     "پس از تایید پرداخت، محصول برای شما ساخته می‌شود."
 )
 
+INSUFFICIENT_BALANCE_DIRECT_PAY_RENEW_DEFAULT = (
+    "‼️ موجودی کیف پول شما کافی نیست\n\n"
+    "💰 مبلغ لازم برای تمدید: ({required} تومان)\n"
+    "📉 کمبود موجودی شما: ({shortfall} تومان)\n"
+    "📦 محصول: {product_label}\n"
+    "📥 حجم: {volume}\n\n"
+    "📌 روی دکمه «افزایش موجودی» بزنید؛ مبلغ به‌صورت خودکار تنظیم می‌شود و "
+    "پس از تایید پرداخت، سرویس شما تمدید می‌شود."
+)
+
 DIRECT_PAY_TOPUP_INTRO_DEFAULT = (
     "💳 پرداخت مستقیم خرید\n\n"
     "📦 محصول: {product_label}\n"
@@ -51,6 +61,16 @@ DIRECT_PAY_TOPUP_INTRO_DEFAULT = (
     "🛒 مبلغ کل خرید: ({required} تومان)\n\n"
     "یک روش پرداخت را انتخاب کنید. نیازی به وارد کردن مبلغ نیست؛ "
     "پس از تایید تراکنش، کانفیگ/پنل برای شما ساخته می‌شود."
+)
+
+DIRECT_PAY_RENEW_TOPUP_INTRO_DEFAULT = (
+    "💳 پرداخت مستقیم تمدید\n\n"
+    "📦 محصول: {product_label}\n"
+    "📥 حجم: {volume}\n"
+    "💰 مبلغ شارژ: ({topup_amount} تومان)\n"
+    "🛒 مبلغ کل تمدید: ({required} تومان)\n\n"
+    "یک روش پرداخت را انتخاب کنید. نیازی به وارد کردن مبلغ نیست؛ "
+    "پس از تایید تراکنش، سرویس شما تمدید می‌شود."
 )
 
 
@@ -68,19 +88,35 @@ def clamp_deposit_amount(amount: int, min_amount: int, max_amount: int) -> int:
     return min(value, int(max_amount))
 
 
-async def prepare_insufficient_direct_pay(
+async def is_direct_pay_enabled() -> bool:
+    """Purchase direct-pay toggle (VPN / reseller buy only)."""
+    settings = await SettingsManager().get_settings()
+    return bool(settings and getattr(settings, "direct_pay_purchase_mode", False))
+
+
+async def is_direct_pay_renew_enabled() -> bool:
+    """Renew direct-pay toggle (VPN config renew only)."""
+    settings = await SettingsManager().get_settings()
+    return bool(settings and getattr(settings, "direct_pay_renew_mode", False))
+
+
+async def mark_direct_pay_ready(
     user_id: int,
     *,
     kind: str,
-    required_amount: int,
+    amount: int,
     product_label: str = "",
     volume: str = "",
 ) -> None:
     await set_data(user_id, REDIS_DIRECT_PAY_READY, "1")
     await set_data(user_id, REDIS_DIRECT_PAY_KIND, kind)
-    await set_data(user_id, REDIS_DIRECT_PAY_AMOUNT, int(required_amount))
+    await set_data(user_id, REDIS_DIRECT_PAY_AMOUNT, int(amount))
     await set_data(user_id, "direct_pay_product_label", product_label or "")
     await set_data(user_id, "direct_pay_volume", volume or "")
+
+
+# Backward-compatible alias used by purchase helpers.
+prepare_insufficient_direct_pay = mark_direct_pay_ready
 
 
 async def build_insufficient_balance_message(
@@ -90,27 +126,35 @@ async def build_insufficient_balance_message(
     kind: str,
     product_label: str = "",
     volume: str = "",
+    renew: bool = False,
 ) -> str:
     user = await UserCRUD().read_user(user_id)
     balance = int(user.amount or 0) if user else 0
     required = int(required_amount)
     shortfall = max(required - balance, 0)
-    settings = await SettingsManager().get_settings()
     lang = user.language if user and user.language else "fa"
 
-    if settings and getattr(settings, "direct_pay_purchase_mode", False):
-        await prepare_insufficient_direct_pay(
+    use_direct = renew or await is_direct_pay_enabled()
+    if use_direct:
+        await mark_direct_pay_ready(
             user_id,
             kind=kind,
-            required_amount=required,
+            amount=required,
             product_label=product_label,
             volume=volume,
         )
-        template = await get_bot_text(
-            key="insufficient_balance_direct_pay",
-            default=INSUFFICIENT_BALANCE_DIRECT_PAY_DEFAULT,
-            lang=lang,
-        )
+        if renew:
+            template = await get_bot_text(
+                key="insufficient_balance_direct_pay_renew",
+                default=INSUFFICIENT_BALANCE_DIRECT_PAY_RENEW_DEFAULT,
+                lang=lang,
+            )
+        else:
+            template = await get_bot_text(
+                key="insufficient_balance_direct_pay",
+                default=INSUFFICIENT_BALANCE_DIRECT_PAY_DEFAULT,
+                lang=lang,
+            )
         return fill_placeholders(
             template,
             required=required,
@@ -137,14 +181,22 @@ async def build_insufficient_balance_message(
 
 async def create_balance_button(user_id: int):
     balance_button_text = await get_button_text("bt.menu_add_balance", "💰 افزایش موجودی")
-    settings = await SettingsManager().get_settings()
     ready = await get_data(user_id, REDIS_DIRECT_PAY_READY)
-    callback = (
-        CALLBACK_DIRECT_PAY_TOPUP
-        if settings and getattr(settings, "direct_pay_purchase_mode", False) and ready
-        else CALLBACK_BACK_TO_BALANCE
-    )
+    kind = await get_data(user_id, REDIS_DIRECT_PAY_KIND)
+    use_direct = False
+    if ready and kind:
+        if kind == direct_pay_store.KIND_RENEW:
+            use_direct = await is_direct_pay_renew_enabled()
+        elif kind in {direct_pay_store.KIND_VPN, direct_pay_store.KIND_RESELLER}:
+            use_direct = await is_direct_pay_enabled()
+    callback = CALLBACK_DIRECT_PAY_TOPUP if use_direct else CALLBACK_BACK_TO_BALANCE
     return [[Button.inline(balance_button_text, data=callback)]]
+
+
+async def create_direct_pay_balance_button(user_id: int):
+    """Always wire the add-balance button to direct-pay top-up callback."""
+    balance_button_text = await get_button_text("bt.menu_add_balance", "💰 افزایش موجودی")
+    return [[Button.inline(balance_button_text, data=CALLBACK_DIRECT_PAY_TOPUP)]]
 
 
 async def build_vpn_payload_from_session(user_id: int) -> dict[str, Any]:
@@ -171,17 +223,41 @@ async def build_reseller_payload_from_session(user_id: int) -> dict[str, Any]:
     }
 
 
-async def start_direct_pay_topup(event) -> bool:
-    """Persist pending purchase to Redis and open payment-method menu with prefilled amount."""
-    user_id = event.sender_id
-    settings = await SettingsManager().get_settings()
-    if not settings or not getattr(settings, "direct_pay_purchase_mode", False):
-        return False
+async def build_renew_payload_from_session(user_id: int) -> dict[str, Any]:
+    config_name = await get_data(user_id, "direct_pay_config_name") or ""
+    discount = await get_data(user_id, "codetakhfif")
+    if discount is None:
+        discount = await get_data(user_id, "discount_code")
+    product_label = await get_data(user_id, "direct_pay_product_label")
+    if not product_label:
+        product_label = f"تمدید {config_name}" if config_name else "تمدید"
+    return {
+        "service_code": await get_data(user_id, "ConfigID"),
+        "panel": await get_data(user_id, "panel"),
+        "selected_plan_id": await get_data(user_id, "selected_plan_id"),
+        "discount_code": discount,
+        "config_name": config_name,
+        "product_label": product_label,
+        "volume": await get_data(user_id, "direct_pay_volume") or "",
+    }
 
+
+async def start_direct_pay_topup(event) -> bool:
+    """Persist pending purchase/renew to Redis and open payment-method menu with prefilled amount."""
+    user_id = event.sender_id
     ready = await get_data(user_id, REDIS_DIRECT_PAY_READY)
     kind = await get_data(user_id, REDIS_DIRECT_PAY_KIND)
     required_raw = await get_data(user_id, REDIS_DIRECT_PAY_AMOUNT)
     if not ready or not kind or required_raw is None:
+        return False
+
+    if kind == direct_pay_store.KIND_RENEW:
+        if not await is_direct_pay_renew_enabled():
+            return False
+    elif kind in {direct_pay_store.KIND_VPN, direct_pay_store.KIND_RESELLER}:
+        if not await is_direct_pay_enabled():
+            return False
+    else:
         return False
 
     required = int(required_raw)
@@ -196,7 +272,7 @@ async def start_direct_pay_topup(event) -> bool:
     elif kind == direct_pay_store.KIND_RESELLER:
         payload = await build_reseller_payload_from_session(user_id)
     else:
-        return False
+        payload = await build_renew_payload_from_session(user_id)
 
     product_label = str(payload.get("product_label") or "")
     volume = str(payload.get("volume") or "")
@@ -218,11 +294,18 @@ async def start_direct_pay_topup(event) -> bool:
     await set_data(user_id, "direct_pay_volume", volume)
 
     lang = user.language if user and user.language else "fa"
-    intro_template = await get_bot_text(
-        key="direct_pay_topup_intro",
-        default=DIRECT_PAY_TOPUP_INTRO_DEFAULT,
-        lang=lang,
-    )
+    if kind == direct_pay_store.KIND_RENEW:
+        intro_template = await get_bot_text(
+            key="direct_pay_renew_topup_intro",
+            default=DIRECT_PAY_RENEW_TOPUP_INTRO_DEFAULT,
+            lang=lang,
+        )
+    else:
+        intro_template = await get_bot_text(
+            key="direct_pay_topup_intro",
+            default=DIRECT_PAY_TOPUP_INTRO_DEFAULT,
+            lang=lang,
+        )
     intro = fill_placeholders(
         intro_template,
         product_label=product_label or "-",
@@ -231,6 +314,7 @@ async def start_direct_pay_topup(event) -> bool:
         required=required,
         shortfall=shortfall,
     )
+    settings = await SettingsManager().get_settings()
     buttons = await create_inline_cartbcard(settings=settings, user=user)
     try:
         await event.edit(intro, buttons=buttons)

--- a/app/services/billing/direct_pay_fulfillment.py
+++ b/app/services/billing/direct_pay_fulfillment.py
@@ -1,4 +1,4 @@
-"""Fulfill direct-pay purchases after wallet credit (Redis pending, no DB table)."""
+"""Fulfill direct-pay purchases/renewals after wallet credit (Redis pending, no DB table)."""
 
 from __future__ import annotations
 
@@ -8,6 +8,7 @@ from app import Kenzo
 from app.db.crud.user import UserCRUD
 from app.logger import get_logger
 from app.services.billing import direct_pay_store
+from app.services.billing.direct_pay_renew import create_vpn_renew_for_user
 from app.telegram.user.reseller.helpers import create_reseller_purchase_for_user
 from app.telegram.user.shop.helpers import create_vpn_purchase_for_user
 from app.utils.text.bot_texts import get_bot_text
@@ -20,15 +21,28 @@ FULFILL_FAILED_DEFAULT = (
     "💰 موجودی فعلی: `{balance}` تومان"
 )
 
+RENEW_FULFILL_FAILED_DEFAULT = (
+    "موجودی شما شارژ شد، اما تمدید خودکار سرویس انجام نشد.\n"
+    "لطفاً دوباره از منوی سرویس‌ها تمدید را انجام دهید یا با پشتیبانی تماس بگیرید.\n"
+    "💰 موجودی فعلی: `{balance}` تومان"
+)
+
 DIRECT_PAY_CANCELLED_DEFAULT = "سفارش پرداخت مستقیم شما لغو شد.\nدر صورت نیاز دوباره مراحل خرید را طی کنید."
 
 
-async def _notify_fulfill_failed(user_id: int, balance: int) -> None:
-    text = await get_bot_text(
-        key="direct_pay_fulfill_failed",
-        default=FULFILL_FAILED_DEFAULT,
-        lang="fa",
-    )
+async def _notify_fulfill_failed(user_id: int, balance: int, *, renew: bool = False) -> None:
+    if renew:
+        text = await get_bot_text(
+            key="direct_pay_renew_fulfill_failed",
+            default=RENEW_FULFILL_FAILED_DEFAULT,
+            lang="fa",
+        )
+    else:
+        text = await get_bot_text(
+            key="direct_pay_fulfill_failed",
+            default=FULFILL_FAILED_DEFAULT,
+            lang="fa",
+        )
     message = text.replace("{balance}", f"{int(balance):,}")
     try:
         await Kenzo.send_message(int(user_id), message)
@@ -49,19 +63,20 @@ async def notify_direct_pay_cancelled(user_id: int) -> None:
 
 
 async def fulfill_pending_record(record: dict[str, Any]) -> bool:
-    """Create product for a claimed pending record. Returns True on success."""
+    """Create product or renew for a claimed pending record. Returns True on success."""
     user_id = int(record["user_id"])
     kind = record.get("kind")
     amount = int(record.get("amount") or 0)
     payload = record.get("payload") or {}
     if not isinstance(payload, dict):
         payload = {}
+    is_renew = kind == direct_pay_store.KIND_RENEW
 
     user = await UserCRUD().read_user(user_id)
     balance = int(user.amount or 0) if user else 0
     if balance < amount:
         await direct_pay_store.mark_status(user_id, "failed")
-        await _notify_fulfill_failed(user_id, balance)
+        await _notify_fulfill_failed(user_id, balance, renew=is_renew)
         return False
 
     try:
@@ -74,6 +89,13 @@ async def fulfill_pending_record(record: dict[str, Any]) -> bool:
             )
         elif kind == direct_pay_store.KIND_RESELLER:
             ok, err = await create_reseller_purchase_for_user(
+                user_id,
+                amount=amount,
+                payload=payload,
+                discount_code=payload.get("discount_code"),
+            )
+        elif is_renew:
+            ok, err = await create_vpn_renew_for_user(
                 user_id,
                 amount=amount,
                 payload=payload,
@@ -94,7 +116,7 @@ async def fulfill_pending_record(record: dict[str, Any]) -> bool:
     await direct_pay_store.mark_status(user_id, "failed")
     user = await UserCRUD().read_user(user_id)
     balance = int(user.amount or 0) if user else balance
-    await _notify_fulfill_failed(user_id, balance)
+    await _notify_fulfill_failed(user_id, balance, renew=is_renew)
     return False
 
 

--- a/app/services/billing/direct_pay_renew.py
+++ b/app/services/billing/direct_pay_renew.py
@@ -1,0 +1,175 @@
+"""Fulfill VPN config renew after direct-pay wallet credit."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pasarguard import PasarguardAPI
+
+from app import Kenzo
+from app.db.crud.discount_codes import DiscountCodeManager
+from app.db.crud.panels import PanelsManager
+from app.db.crud.plans import PlanManager
+from app.db.crud.services import ServiceCRUD
+from app.logger import LogType, get_logger
+from app.services.billing.renewal import (
+    PaidRenewalError,
+    execute_paid_service_renewal,
+    require_panel_userid,
+)
+from app.telegram.shared.utils.logging import send_log_message
+from app.telegram.state import clear_user
+from app.utils.formatting.conversions import convert_storage
+from app.utils.formatting.dates import Time_Date
+from app.utils.formatting.traffic import format_size
+from app.utils.text.bot_texts import get_bot_text
+
+logger = get_logger(__name__)
+
+RENEWAL_SUCCESS_DEFAULT = (
+    "✅ از اعتماد شما ممنونیم !\n\n"
+    "🎉 اکانت شما با مشخصات زیر تمدید شد :\n\n"
+    "🎫 کد سرویس: {service_code}\n"
+    "📝 نام کانفیگ: {config_name}\n"
+    "📥 پلن انتخابی: {plan_name}\n"
+    "📥 حجم جدید شما: {new_volume}\n"
+    "⏳ تاریخ انقضا اکانت: {expiration_date}\n\n"
+    "💰 مبلغ {price} هزارتومان از موجودی شما کسر شد.\n\n"
+    "💵 موجودی جدید کیف‌پول شما:\n"
+    "{new_balance} هزارتومان\n\n"
+    "🌐 جهت مدیریت اکانت ها روی /myaccount کلیک کنید."
+)
+
+
+async def create_vpn_renew_for_user(
+    user_id: int,
+    *,
+    amount: int,
+    payload: dict[str, Any] | None = None,
+    discount_code: str | None = None,
+) -> tuple[bool, str]:
+    """Renew an existing VPN config after direct-pay credit. Idempotent caller claims first."""
+    payload = payload if isinstance(payload, dict) else {}
+    service_code = payload.get("service_code")
+    panel_code = payload.get("panel")
+    plan_id = payload.get("selected_plan_id")
+    discount_code = discount_code or payload.get("discount_code")
+
+    if service_code is None or panel_code is None or plan_id is None:
+        return False, "missing_context"
+
+    try:
+        plan_id_int = int(plan_id)
+        service_code_int = int(service_code)
+    except TypeError, ValueError:
+        return False, "invalid_ids"
+
+    plan = await PlanManager().get_plan(plan_id_int)
+    if not plan:
+        return False, "plan_not_found"
+
+    ok, service = await ServiceCRUD().get_service(code=service_code_int)
+    if not ok or not service:
+        return False, "service_not_found"
+    if int(service.id) != int(user_id):
+        return False, "not_owner"
+    if getattr(service, "is_test", False) is True:
+        return False, "test_service"
+
+    panel = await PanelsManager().get_panel_by_code(code=panel_code)
+    if not panel:
+        return False, "panel_not_found"
+
+    price = int(amount)
+    if discount_code:
+        status, _res = await DiscountCodeManager().validate_discount_code(code=discount_code, user_id=user_id)
+        if not status:
+            discount_code = None
+
+    try:
+        panel_user = await PasarguardAPI(panel.base_url).get_user_by_id(
+            user_id=require_panel_userid(service),
+            token=panel.cookie,
+        )
+        new_hajm, new_balance = await execute_paid_service_renewal(
+            service,
+            panel,
+            plan,
+            price=price,
+            panel_user=panel_user,
+        )
+    except PaidRenewalError as exc:
+        logger.warning("direct_pay renew paid error user=%s: %s", user_id, exc)
+        return False, str(exc)
+    except Exception as exc:
+        logger.exception("direct_pay renew error user=%s: %s", user_id, exc)
+        return False, str(exc)
+
+    if discount_code:
+        await DiscountCodeManager().update_discount_usage(code=discount_code)
+
+    gig = float(plan.storage)
+    plan_name = convert_storage(
+        gig,
+        getattr(plan, "plan_type", None),
+        getattr(plan, "data_limit_reset_strategy", None),
+    )
+    ip_limit = getattr(plan, "ip_limit", 0)
+    plan_name_with_limit = f"{plan_name} [{ip_limit}] کاربره" if ip_limit and ip_limit > 0 else plan_name
+    config_name = str(payload.get("config_name") or service.username or "")
+
+    success_text_template = await get_bot_text(
+        key="renewal_success_text",
+        default=RENEWAL_SUCCESS_DEFAULT,
+        lang="fa",
+    )
+    expiration_date_text = f"{plan.duration} روز دیگر"
+    txt = (
+        success_text_template.replace("{service_code}", str(service_code_int))
+        .replace("{config_name}", config_name)
+        .replace("{plan_name}", plan_name_with_limit)
+        .replace("{new_volume}", format_size(new_hajm, decimal_places=0))
+        .replace("{expiration_date}", expiration_date_text)
+        .replace("{price}", f"{price:,}")
+        .replace("{new_balance}", f"{new_balance:,}")
+    )
+
+    if discount_code:
+        log_text = (
+            f"📢 ** تمدید جدید با کدتخفیف (پرداخت مستقیم)**\n\n"
+            f"👤 شناسه کاربر: `{user_id}`\n"
+            f"📅 تاریخ خرید (میلادی): `{Time_Date()['mf']}`\n"
+            f"📅 تاریخ خرید (شمسی): `{Time_Date()['jf']}`\n"
+            f"🎫 کد سرویس: `{service_code_int}`\n"
+            f"🎟 **کدتخفیف استفاده شده:** `{discount_code}`\n"
+            f"**🔷 اسم کانفیگ:** `{config_name}`\n"
+            f"**📥 حجم انتخابی کاربر:** {plan_name}\n"
+            f"**📥 حجم جدید کاربر :** `{format_size(new_hajm, decimal_places=2)}`\n"
+            f"**⏳ زمان جدید کانفیگ: {plan.duration} روز**\n"
+            f"💸 مبلغ بدون تخفیف: `{int(plan.price):,}` تومان\n"
+            f"💸 مبلغ پرداخت شده: `{price:,}` تومان\n"
+            f"💵 موجودی جدید کاربر: `{new_balance:,}` تومان\n."
+        )
+    else:
+        log_text = (
+            f"📢 ** تمدید جدید بدون کدتخفیف (پرداخت مستقیم)**\n\n"
+            f"👤 شناسه کاربر: `{user_id}`\n"
+            f"📅 تاریخ خرید (میلادی): `{Time_Date()['mf']}`\n"
+            f"📅 تاریخ خرید (شمسی): `{Time_Date()['jf']}`\n"
+            f"🎫 کد سرویس: `{service_code_int}`\n"
+            f"**🔷 اسم کانفیگ:** `{config_name}`\n"
+            f"**📥 حجم انتخابی کاربر:** {plan_name}\n"
+            f"**📥 حجم جدید کاربر :** `{format_size(new_hajm, decimal_places=2)}`\n"
+            f"**⏳ زمان جدید کانفیگ: {plan.duration} روز**\n"
+            f"💸 مبلغ پرداخت شده: `{price:,}` تومان\n"
+            f"💵 موجودی جدید کاربر: `{new_balance:,}` تومان\n."
+        )
+
+    try:
+        await Kenzo.send_message(int(user_id), txt)
+    except Exception as exc:
+        logger.warning("direct_pay renew notify user=%s: %s", user_id, exc)
+
+    await send_log_message(LogType.OTHER, message=log_text)
+    await clear_user(user_id)
+    return True, ""

--- a/app/services/billing/direct_pay_store.py
+++ b/app/services/billing/direct_pay_store.py
@@ -23,6 +23,7 @@ logger = get_logger(__name__)
 ACTIVE_STATUSES = frozenset({"pending", "linked"})
 KIND_VPN = "vpn"
 KIND_RESELLER = "reseller"
+KIND_RENEW = "renew"
 
 DIRECT_PAY_TTL_SECONDS = max(int(STATE_TTL_SECONDS or 86400), 86400)
 

--- a/app/telegram/keyboards/settings.py
+++ b/app/telegram/keyboards/settings.py
@@ -78,6 +78,7 @@ SETTINGS_MENU_SECTIONS = (
             SettingsMenuItem("دکمه دریافت تست", "test_mode"),
             SettingsMenuItem("تایید شماره تست", "test_phone_verify", default=True, wide=True),
             SettingsMenuItem("پرداخت مستقیم خرید", "direct_pay_purchase_mode", wide=True),
+            SettingsMenuItem("پرداخت مستقیم تمدید", "direct_pay_renew_mode", wide=True),
         ),
     ),
     SettingsMenuSection(

--- a/app/telegram/keyboards/texts.py
+++ b/app/telegram/keyboards/texts.py
@@ -159,6 +159,17 @@ TEXT_KEYS_CONFIG = {
             },
         },
         {
+            "key": "insufficient_balance_direct_pay_renew",
+            "title": "پیام کمبود موجودی (پرداخت مستقیم تمدید)",
+            "placeholders": {
+                "required": "مبلغ لازم",
+                "shortfall": "کمبود موجودی",
+                "product_label": "نام محصول",
+                "volume": "حجم",
+                "balance": "موجودی فعلی",
+            },
+        },
+        {
             "key": "direct_pay_topup_intro",
             "title": "معرفی پرداخت مستقیم پس از کلیک افزایش موجودی",
             "placeholders": {
@@ -170,8 +181,24 @@ TEXT_KEYS_CONFIG = {
             },
         },
         {
+            "key": "direct_pay_renew_topup_intro",
+            "title": "معرفی پرداخت مستقیم تمدید پس از کلیک افزایش موجودی",
+            "placeholders": {
+                "product_label": "نام محصول",
+                "volume": "حجم",
+                "topup_amount": "مبلغ شارژ",
+                "required": "مبلغ کل تمدید",
+                "shortfall": "کمبود موجودی",
+            },
+        },
+        {
             "key": "direct_pay_fulfill_failed",
             "title": "خطای ساخت خودکار پس از شارژ",
+            "placeholders": {"balance": "موجودی فعلی"},
+        },
+        {
+            "key": "direct_pay_renew_fulfill_failed",
+            "title": "خطای تمدید خودکار پس از شارژ",
             "placeholders": {"balance": "موجودی فعلی"},
         },
         {

--- a/app/telegram/user/balance/messages.py
+++ b/app/telegram/user/balance/messages.py
@@ -23,6 +23,7 @@ from app.db.crud.user import UserCRUD
 from app.db.crud.wallets import WalletCRUD
 from app.logger import LogType, get_logger
 from app.services.billing.direct_pay_flow import (
+    DIRECT_PAY_RENEW_TOPUP_INTRO_DEFAULT,
     DIRECT_PAY_TOPUP_INTRO_DEFAULT,
     REDIS_DIRECT_PAY_ACTIVE,
     REDIS_MABLAGH,
@@ -31,6 +32,7 @@ from app.services.billing.direct_pay_flow import (
 )
 from app.services.billing.direct_pay_store import (
     ACTIVE_STATUSES,
+    KIND_RENEW,
     cancel_pending_for_user,
     get_pending_for_user,
     link_crypto_order,
@@ -188,11 +190,18 @@ async def return_to_balance_menu(event) -> None:
         volume = str(payload.get("volume") or "-")
         await set_data(user_id, REDIS_DIRECT_PAY_ACTIVE, "1")
         await set_data(user_id, REDIS_MABLAGH, topup)
-        intro_template = await get_bot_text(
-            key="direct_pay_topup_intro",
-            default=DIRECT_PAY_TOPUP_INTRO_DEFAULT,
-            lang=lang,
-        )
+        if pending.get("kind") == KIND_RENEW:
+            intro_template = await get_bot_text(
+                key="direct_pay_renew_topup_intro",
+                default=DIRECT_PAY_RENEW_TOPUP_INTRO_DEFAULT,
+                lang=lang,
+            )
+        else:
+            intro_template = await get_bot_text(
+                key="direct_pay_topup_intro",
+                default=DIRECT_PAY_TOPUP_INTRO_DEFAULT,
+                lang=lang,
+            )
         intro_text = fill_placeholders(
             intro_template,
             product_label=product_label,

--- a/app/telegram/user/services/callbacks.py
+++ b/app/telegram/user/services/callbacks.py
@@ -22,7 +22,13 @@ from app.db.crud.services import ServiceCRUD
 from app.db.crud.settings import SettingsManager
 from app.db.crud.user import UserCRUD, update_Money
 from app.logger import LogType, get_logger
-from app.services.billing.direct_pay_store import cancel_pending_for_user
+from app.services.billing.direct_pay_flow import (
+    build_insufficient_balance_message,
+    create_direct_pay_balance_button,
+    is_direct_pay_renew_enabled,
+    mark_direct_pay_ready,
+)
+from app.services.billing.direct_pay_store import KIND_RENEW, cancel_pending_for_user
 from app.services.billing.renewal import (
     apply_panel_user_renewal,
     preview_remaining_after_renewal,
@@ -120,7 +126,7 @@ async def service_callback_handler(event: events.CallbackQuery.Event, data: str 
             if getattr(result, "is_test", False) is True:
                 await event.answer("سرویس‌های تست قابل تمدید یا ارتقا نیستند.", alert=True)
                 return
-            # Direct-pay is buy-only; abandon any leftover purchase pending.
+            # Cancel leftover buy pendings; renew pending is created only after insufficient + topup.
             await cancel_pending_for_user(event.sender_id)
             panel_manager = PanelsManager()
             panel = await panel_manager.get_panel_by_code(result.in_panel)
@@ -425,7 +431,32 @@ async def service_callback_handler(event: events.CallbackQuery.Event, data: str 
         is_sufficient, message = await check_user_balance(event.sender_id, plan.price)
         if not is_sufficient:
             await cancel_pending_for_user(event.sender_id)
-            await event.edit(message, buttons=await create_balance_button(event.sender_id))
+            if await is_direct_pay_renew_enabled():
+                volume_text = (
+                    f"{convert_storage(gig, getattr(plan, 'plan_type', None), getattr(plan, 'data_limit_reset_strategy', None))}"
+                    f" / {plan.duration} روز"
+                )
+                product_label = f"تمدید {serv_msg.username}"
+                await set_data(event.sender_id, "selected_plan_id", plan_id)
+                await set_data(event.sender_id, "direct_pay_config_name", serv_msg.username)
+                await mark_direct_pay_ready(
+                    event.sender_id,
+                    kind=KIND_RENEW,
+                    amount=int(plan.price),
+                    product_label=product_label,
+                    volume=volume_text,
+                )
+                message = await build_insufficient_balance_message(
+                    event.sender_id,
+                    int(plan.price),
+                    kind=KIND_RENEW,
+                    product_label=product_label,
+                    volume=volume_text,
+                    renew=True,
+                )
+                await event.edit(message, buttons=await create_direct_pay_balance_button(event.sender_id))
+            else:
+                await event.edit(message, buttons=await create_balance_button(event.sender_id))
         else:
             try:
                 panel = await PanelsManager().get_panel_by_code(code=panelcode)
@@ -560,7 +591,32 @@ async def service_callback_handler(event: events.CallbackQuery.Event, data: str 
         is_sufficient, message = await check_user_balance(event.sender_id, new_price)
         if not is_sufficient:
             await cancel_pending_for_user(event.sender_id)
-            await event.edit(message, buttons=await create_balance_button(event.sender_id))
+            if await is_direct_pay_renew_enabled():
+                volume_text = (
+                    f"{convert_storage(float(gig), getattr(plan, 'plan_type', None), getattr(plan, 'data_limit_reset_strategy', None))}"
+                    f" / {plan.duration} روز"
+                )
+                product_label = f"تمدید {serv_msg.username}"
+                await set_data(event.sender_id, "selected_plan_id", plan_id)
+                await set_data(event.sender_id, "direct_pay_config_name", serv_msg.username)
+                await mark_direct_pay_ready(
+                    event.sender_id,
+                    kind=KIND_RENEW,
+                    amount=int(new_price),
+                    product_label=product_label,
+                    volume=volume_text,
+                )
+                message = await build_insufficient_balance_message(
+                    event.sender_id,
+                    int(new_price),
+                    kind=KIND_RENEW,
+                    product_label=product_label,
+                    volume=volume_text,
+                    renew=True,
+                )
+                await event.edit(message, buttons=await create_direct_pay_balance_button(event.sender_id))
+            else:
+                await event.edit(message, buttons=await create_balance_button(event.sender_id))
 
         else:
             try:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "PasarguardBot"
-version = "1.2.8"
+version = "1.2.9"
 description = "Pasarguard Telegram bot"
 requires-python = ">=3.14,<3.15"
 dependencies = [


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added direct-pay support for VPN service renewals.
  * Users can top up their balance and automatically complete eligible renewals.
  * Added renewal-specific prompts, confirmations, and failure messages.
  * Added a separate setting to enable or disable direct-pay renewals.

* **Improvements**
  * Renewal payments now preserve relevant plan, service, discount, and balance details.
  * Balance prompts and payment buttons now adapt to purchase or renewal flows.

* **Chores**
  * Updated the application version to 1.2.9.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->