### PR TITLE
Ignore fumadocs-ui in Dependabot due to npm alias errors

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,10 +7,6 @@ updates:
     schedule:
       interval: "daily"
     open-pull-requests-limit: 10
-    groups:
-      python-dependencies:
-        patterns:
-          - "*"
 
   - package-ecosystem: "bun"
     directory: "/docs"
@@ -18,10 +14,8 @@ updates:
     schedule:
       interval: "daily"
     open-pull-requests-limit: 10
-    groups:
-      docs-dependencies:
-        patterns:
-          - "*"
+    ignore:
+      - dependency-name: "fumadocs-ui"
 
   - package-ecosystem: "docker"
     directory: "/"
@@ -29,10 +23,6 @@ updates:
     schedule:
       interval: "daily"
     open-pull-requests-limit: 5
-    groups:
-      docker-dependencies:
-        patterns:
-          - "*"
 
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -40,7 +30,3 @@ updates:
     schedule:
       interval: "daily"
     open-pull-requests-limit: 5
-    groups:
-      github-actions:
-        patterns:
-          - "*"


### PR DESCRIPTION
## Summary
<!-- What does this PR change and why? -->

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Docs
- [ ] CI / tooling

## Test plan
- [ ] `ruff check` / `ruff format --check` pass locally
- [ ] Manual bot smoke (if UI/flow changed)
- [ ] Docs preview (if `docs/` changed)

## Notes
<!-- Breaking changes, follow-ups, screenshots -->
